### PR TITLE
Set an 'offset' on the marker definition

### DIFF
--- a/_includes/map.html
+++ b/_includes/map.html
@@ -25,7 +25,8 @@
           {
             w: 20,
             h: 30
-          }
+          },
+          new OpenLayers.Pixel(-10, -30)
         )
       )
     );


### PR DESCRIPTION
If you set the size on an OpenLayers marker it tends to mess up the 'anchor' position of the marker graphic, and the marker will seem to point at a location on the map which drifts slightly as you zoom in and out

To see the problem on one of your gig pages, zoom right out and watch where it's point as you zoom.

This marker graphic (like most) is designed to point to a location at the very bottom of the graphic in the middle. The correct offset from the map location, is therefore:  x minus half the graphic width (the middle), and y minus the full graphic height (the bottom).